### PR TITLE
Fix to support installing all scripts into Python path

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,16 @@ import os
 def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
+
+def find_scripts():
+    scripts = []
+    exclude = ['setup.py']
+    for file in os.scandir('.'):
+        if file.name.endswith('.py') and file.is_file() and (file.name not in exclude):
+            scripts.append(file.name)
+    return scripts
+
+
 setup(
     name='cb-response-surveyor',
     author='Keith McCammon',
@@ -14,6 +24,7 @@ setup(
     url='https://github.com/redcanaryco/cb-response-surveyor',
     license='MIT',
     packages=find_packages(),
+    scripts=find_scripts(),
     description='Extracts summarized process data from Cb Enterprise Response ',
     version='0.1',
     classifiers=[


### PR DESCRIPTION
Similar as the fix for `redcanary-response-utils` (https://github.com/redcanaryco/redcanary-response-utils/pull/18). `setup.py` will now search for all `.py` files (except for `setup.py`) and install them into the Python path, making them callable from anywhere on the system.