### PR TITLE
Update Arguments for search and remote-admin definitions

### DIFF
--- a/definitions/remote-admin.json
+++ b/definitions/remote-admin.json
@@ -56,5 +56,9 @@
         "process_name": ["winvnc.exe", 
                          "vncviewer.exe",
                          "winvncsc.exe"]
-    }
+    },
+    "Splashtop": {
+        "process_name": ["srmanager.exe",
+                         "strwinclt.exe"]
+    }	
 }

--- a/surveyor.py
+++ b/surveyor.py
@@ -61,7 +61,8 @@ def process_search(cb_conn, query, query_base=None):
       results.add((proc.hostname.lower(),
             proc.username.lower(), 
             proc.path,
-            proc.cmdline))
+            proc.cmdline,
+            proc.group))
   except KeyboardInterrupt:
     log("Caught CTRL-C. Returning what we have . . .\n")
 
@@ -83,7 +84,8 @@ def nested_process_search(cb_conn, criteria, query_base=None):
         results.add((proc.hostname.lower(),
                      proc.username.lower(), 
                      proc.path,
-                     proc.cmdline))
+                     proc.cmdline,
+                     proc.group))
   except KeyboardInterrupt:
     log("Caught CTRL-C. Returning what we have . . .")
 
@@ -117,6 +119,8 @@ def main():
                       help="Target specific host by name.")
   parser.add_argument('--username', type=str, action="store",
                       help="Target specific username.")
+  parser.add_argument('--group', type=str, action="store",
+                      help="Target specific sensor group")
 
   # IOC survey criteria
   parser.add_argument('--ioctype', type=str, action="store", 
@@ -147,6 +151,11 @@ def main():
     if args.query and 'username' in args.query:
       parser.error('Cannot use --username with "username:" (in query)')
     query_base += ' username:%s' % args.username
+    
+  if args.group:
+    if args.query and 'group' in args.query:
+      parser.error('Cannot use --group with "group:" (in query)')
+    query_base += ' group:%s' % args.group 
 
   definition_files = []
   if args.deffile:


### PR DESCRIPTION
Add the "group" argument to allow users to narrow down the search scope of surveyor. 

Also added Splashtop to the remote-admin definitions.  

Edit:  Just noticed that another user submitted a pull request for "group" argument filter so some of this may be duplicative. 